### PR TITLE
updating max_results -> results_per_call in the payload generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ It can be far easier to specify your information in a configuration file. An exa
   [gnip_search_rules]
   from_date = 2017-06-01
   to_date = 2017-09-01
-  max_results = 100
+  results_per_call = 100
   pt_rule = beyonce has:hashtags
 
 
@@ -230,7 +230,7 @@ what a rule looks like.
 
 .. code:: python
 
-    rule = gen_rule_payload("@robotprincessfi", max_results=100) # testing with a sandbox account
+    rule = gen_rule_payload("@robotprincessfi", results_per_call=100) # testing with a sandbox account
     print(rule)
 
 
@@ -334,7 +334,7 @@ stop on number of pages to limit your API call usage.
             "maxResults":100
         },
         "tweetify":true,
-        "max_results":500
+        "results_per_call":500
     }
 
 
@@ -464,7 +464,7 @@ method; please see your developer console for details.
 
 .. code:: python
 
-    rule = gen_rule_payload("from:jack", from_date="2017-09-01", to_date="2017-10-30", max_results=100)
+    rule = gen_rule_payload("from:jack", from_date="2017-09-01", to_date="2017-10-30", results_per_call=100)
     print(rule)
 
 

--- a/examples/api_example.ipynb
+++ b/examples/api_example.ipynb
@@ -122,7 +122,7 @@
     }
    ],
    "source": [
-    "rule = gen_rule_payload(\"@robotprincessfi\", max_results=100) # testing with a sandbox account\n",
+    "rule = gen_rule_payload(\"@robotprincessfi\", results_per_call=100) # testing with a sandbox account\n",
     "print(rule)"
    ]
   },
@@ -255,7 +255,7 @@
       "        \"maxResults\":100\n",
       "    },\n",
       "    \"tweetify\":true,\n",
-      "    \"max_results\":500\n",
+      "    \"results_per_call\":500\n",
       "}\n"
      ]
     }

--- a/examples/readme.rst
+++ b/examples/readme.rst
@@ -91,7 +91,7 @@ what a rule looks like.
 
 .. code:: python
 
-    rule = gen_rule_payload("@robotprincessfi", max_results=100) # testing with a sandbox account
+    rule = gen_rule_payload("@robotprincessfi", results_per_call=100) # testing with a sandbox account
     print(rule)
 
 
@@ -135,7 +135,7 @@ Let's see how it goes:
 
 .. code:: python
 
-    tweets = collect_results(rule, max_results=500, result_stream_args=premium_search_args) # change this if you need to
+    tweets = collect_results(rule, results_per_call=500, result_stream_args=premium_search_args) # change this if you need to
 
 
 .. parsed-literal::
@@ -195,7 +195,7 @@ stop on number of pages to limit your API call usage.
             "maxResults":100
         },
         "tweetify":true,
-        "max_results":500
+        "results_per_call":500
     }
 
 
@@ -327,7 +327,7 @@ method; please see your developer console for details.
 
 .. code:: python
 
-    rule = gen_rule_payload("from:jack", from_date="2017-09-01", to_date="2017-10-30", max_results=100)
+    rule = gen_rule_payload("from:jack", from_date="2017-09-01", to_date="2017-10-30", results_per_call=100)
     print(rule)
 
 

--- a/twittersearch/api_utils.py
+++ b/twittersearch/api_utils.py
@@ -107,7 +107,7 @@ def change_to_count_endpoint(endpoint):
         return "https://" + '/'.join(filt_tokens) + '/' + "counts.json"
 
 
-def gen_rule_payload(pt_rule, max_results=500,
+def gen_rule_payload(pt_rule, results_per_call=500,
                      from_date=None, to_date=None, count_bucket=None,
                      tag=None,
                      stringify=True):
@@ -119,7 +119,8 @@ def gen_rule_payload(pt_rule, max_results=500,
         pt_rule (str): The string version of a powertrack rule,
             e.g., "kanye west has:geo". Accepts multi-line strings
             for ease of entry.
-        max_results (int): max results for the batch.
+        results_per_call (int): number of tweets or counts returned per API
+        call. This maps to the ``maxResults`` search API parameter.
             Defaults to 500 to reduce API call usage.
         from_date (str or None): Date format as specified by
             `convert_utc_time` for the starting time of your search.
@@ -140,7 +141,7 @@ def gen_rule_payload(pt_rule, max_results=500,
     """
 
     pt_rule = ' '.join(pt_rule.split())  # allows multi-line strings
-    payload = {"query": pt_rule, "maxResults": max_results}
+    payload = {"query": pt_rule, "maxResults": results_per_call}
     if to_date:
         payload["toDate"] = convert_utc_time(to_date)
     if from_date:
@@ -175,7 +176,7 @@ def gen_params_from_config(config_dict):
     rule = gen_rule_payload(pt_rule=config_dict["pt_rule"],
                             from_date=config_dict.get("from_date", None),
                             to_date=config_dict.get("to_date", None),
-                            max_results=int(config_dict.get("max_results")),
+                            results_per_call=int(config_dict.get("results_per_call")),
                             count_bucket=config_dict.get("count_bucket", None))
 
     _dict = {"endpoint": endpoint,


### PR DESCRIPTION
Per discussion with @fionapigott and @jrmontag, we can change the parameter `max_results` in the payload generation functions to `results_per_call` to ensure clarity in the API. the `ResultStream` object takes a `max_results` value, which controls how many total tweets or counts it will return from a stream.

I think this simplifies the api a bit, even if there is less concordance between `results_per_call` and `maxResults` in the actual API. 

Thanks for the suggestions; I will wait for @twitterdev/des-science feedback before merging this. 